### PR TITLE
Making results table more friendly

### DIFF
--- a/app/scripts/sizer-soze.js
+++ b/app/scripts/sizer-soze.js
@@ -36,7 +36,6 @@
   };
 
   var bytesToSize = function( bytes ) {
-    console.log(bytes);
     var sizes = ["Bytes", "KB", "MB"],
         i,
         isPositive = (bytes > 0) ? 1 : -1;

--- a/app/scripts/sizer-soze.js
+++ b/app/scripts/sizer-soze.js
@@ -35,11 +35,31 @@
     req.send();
   };
 
+  var bytesToSize = function( bytes ) {
+    console.log(bytes);
+    var sizes = ["Bytes", "KB", "MB"],
+        i,
+        isPositive = (bytes > 0) ? 1 : -1;
+    if (bytes === 0) return "0 Bytes";
 
+    i = parseInt(Math.floor(Math.log(bytes * isPositive) / Math.log(1024)), 10);
+    return (bytes / Math.pow(1024, i)).toFixed(2) + ' ' + sizes[i];
+    
+    
+  };
   var createTable = function( arr ){
     var table = document.createElement( "table" ),
       tbody = document.createElement( "tbody" ),
       thead = document.createElement( "thead" ),
+      header = document.createElement("h1"),
+      conclusion = document.createElement('p'),
+      headers = {
+        "viewport": "Breakpoint",
+        "image_data": "Original Weight",
+        "lossless": "Lossless Savings",
+        "lossy": "Lossy Savings",
+        "resize": "Resized Savings"
+      },
       tr, td, summary, summary2, results;
 
     results = document.querySelectorAll( ".sizer-results" );
@@ -48,10 +68,11 @@
 
     //HEAD
     summary2 = arr[0].summary;
+    header.innerHTML = "Results for " + summary2["url"];
     tr = document.createElement( "tr" );
-    for( var k in summary2 ){
+    for( var k in headers ){
       td = document.createElement( "td" );
-      td.innerHTML = k;
+      td.innerHTML = headers[k];
       tr.appendChild( td );
     }
     thead.appendChild( tr );
@@ -61,10 +82,9 @@
     for( var i = 0, l = arr.length; i < l; i++ ){
       tr = document.createElement( "tr" );
       summary = arr[i].summary;
-      for( var j in summary ){
-        console.log( j );
+      for( var j in headers ){
         td = document.createElement( "td" );
-        td.innerHTML = summary[j];
+        td.innerHTML = (j === 'viewport') ? summary[j] : bytesToSize(summary[j]);
         tr.appendChild( td );
       }
       tbody.appendChild( tr );
@@ -76,6 +96,7 @@
       if( iframe ){
         r.removeChild( iframe );
       }
+      r.appendChild( header );
       r.appendChild( table );
     }
   };

--- a/app/scripts/sizer-soze.js
+++ b/app/scripts/sizer-soze.js
@@ -60,7 +60,7 @@
         "lossy": "Lossy Savings",
         "resize": "Resized Savings"
       },
-      tr, td, summary, summary2, results;
+      tr, td, th, summary, summary2, results;
 
     results = document.querySelectorAll( ".sizer-results" );
 
@@ -71,14 +71,14 @@
     header.innerHTML = "Results for " + summary2["url"];
     tr = document.createElement( "tr" );
     for( var k in headers ){
-      td = document.createElement( "td" );
-      td.innerHTML = headers[k];
-      tr.appendChild( td );
+      th = document.createElement( "th" );
+      th.innerHTML = headers[k];
+      tr.appendChild( th );
     }
     //Let's show a percentage here too
-    td = document.createElement( "td" );
-    td.innerHTML = "% Savings";
-    tr.appendChild( td );
+    th = document.createElement( "th" );
+    th.innerHTML = "% Savings";
+    tr.appendChild( th );
 
     thead.appendChild( tr );
     table.appendChild( thead );

--- a/app/scripts/sizer-soze.js
+++ b/app/scripts/sizer-soze.js
@@ -77,7 +77,7 @@
     }
     //Let's show a percentage here too
     td = document.createElement( "td" );
-    td.innerHTML = "Potential Savings";
+    td.innerHTML = "% Savings";
     tr.appendChild( td );
 
     thead.appendChild( tr );

--- a/app/scripts/sizer-soze.js
+++ b/app/scripts/sizer-soze.js
@@ -75,6 +75,11 @@
       td.innerHTML = headers[k];
       tr.appendChild( td );
     }
+    //Let's show a percentage here too
+    td = document.createElement( "td" );
+    td.innerHTML = "Potential Savings";
+    tr.appendChild( td );
+
     thead.appendChild( tr );
     table.appendChild( thead );
 
@@ -87,6 +92,15 @@
         td.innerHTML = (j === 'viewport') ? summary[j] : bytesToSize(summary[j]);
         tr.appendChild( td );
       }
+      //Let's show a percentage here too
+      td = document.createElement( "td" );
+      if (summary["image_data"] !== 0 && summary["resize"] !== 0) {
+        td.innerHTML = Math.floor(( summary["resize"] / summary["image_data"] ) * 100) + "%";
+      } else {
+        td.innerHTML = "0%";
+      }
+      tr.appendChild( td );
+
       tbody.appendChild( tr );
     }
     table.appendChild( tbody );

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -237,18 +237,15 @@ footer {
   table{
     width: 100%;
 
-    td{
+    td, th{
       padding: .5em;
     }
-  }
-  thead {
-    td{
+
+    th {
       font-weight: bold;
       text-align: center;
     }
-  }
-  tbody {
-    td {
+    td{
       text-align: right;
     }
   }

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -222,6 +222,38 @@ footer {
   }
 }
 
+.sizer-results {
+  font-family: Lato;
+
+  h1 {
+    font-family: Lato;
+    font-size: 25px;
+    font-weight: 500;
+    color: #640f09;
+    margin: 25px 0 20px;
+    position: relative;
+    text-align: center;
+  }
+  table{
+    width: 100%;
+
+    td{
+      padding: .5em;
+    }
+  }
+  thead {
+    td{
+      font-weight: bold;
+      text-align: center;
+    }
+  }
+  tbody {
+    td {
+      text-align: right;
+    }
+  }
+
+}
 .input {
   padding: 15px 30px;
   margin: 15px 0 10px;


### PR DESCRIPTION
Per #18, the Sizer-Soze results are a little more reader-friendly. Bytes are converted to KB and MB, where appropriate (and yeah, it _is_ sad that MB are often appropriate) and more readable headers are on the table.

I also added a column for total savings as a percentage, for people who want an "at-a-glance" sort of perspective.

@wilto—You can find an example of the generated HTML at https://gist.github.com/tkadlec/9356892. I didn't do anything fancy at all there—figure we can adjust that.
